### PR TITLE
Unset minimal USE flag for vim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 DESTDIR =
-ETC_DIRS = env.d
+ETC_DIRS = env.d portage
 LIB_DIRS = modprobe.d sysctl.d tmpfiles.d
 SHARE_DIRS = baselayout sudoers.d vim
 

--- a/portage/package.use/vim
+++ b/portage/package.use/vim
@@ -1,0 +1,1 @@
+app-editors/vim -minimal


### PR DESCRIPTION
This patch unsets "minimal" for vim only.  It also enables easy access
to set specialized USE flags for other packages using the standard,
Gentoo-style /etc/portage/package.\* system overrides.

This is, specifically, intended to address the availability of vim "visual" mode, as referenced in the mailing list.
