### PR TITLE
feat(tmpfiles) add some more /etc symlinks

### DIFF
--- a/tmpfiles.d/baselayout-etc.conf
+++ b/tmpfiles.d/baselayout-etc.conf
@@ -4,6 +4,8 @@ L   /etc/issue          -   -   -   -   ../usr/share/baselayout/issue
 L   /etc/motd           -   -   -   -   ../usr/share/baselayout/motd
 L   /etc/mtab           -   -   -   -   /proc/self/mounts
 L   /etc/nsswitch.conf  -   -   -   -   ../usr/share/baselayout/nsswitch.conf
+L   /etc/os-release     -   -   -   -   ../usr/share/coreos/os-release
+L   /etc/lsb-release    -   -   -   -   ../usr/share/coreos/lsb-release
 L   /etc/profile        -   -   -   -   ../usr/share/baselayout/profile
 L   /etc/shells         -   -   -   -   ../usr/share/baselayout/shells
 d   /etc/vim            -   -   -   -   -


### PR DESCRIPTION
Support was added for the following symlinks:
  /etc/os-release  -> /usr/share/coreos/os-release
  /etc/lsb-release -> /usr/share/coreos/lsb-release

Other packages create these files, but if they get removed from the
system, they will be properly re-created now by the systemd-tmpfiles
program.
