### PR TITLE
fix(sysctl): Increase watchdog timeouts and reboot delay after panic

### DIFF
--- a/sysctl.d/baselayout.conf
+++ b/sysctl.d/baselayout.conf
@@ -8,12 +8,5 @@ net.ipv4.conf.default.rp_filter = 1
 # Enable reverse path
 net.ipv4.conf.all.rp_filter = 1
 
-# Set watchdog_thresh
-kernel.watchdog_thresh = 5
-# When the kernel panics, automatically reboot to preserve dump in ram
-kernel.panic = -1
-# Reboot on oops as well
-kernel.panic_on_oops = 1
-
 # Disable kernel address visibility to non-root users.
 kernel.kptr_restrict = 1


### PR DESCRIPTION
The default watchdog is 10 seconds, we are using 5 which is perhaps a
bit too aggressive.

The kernel is also configured to delay rebooting after panic for 60
seconds, giving users a chance to see the error first. We don't do
anything to collect any panic info that may be preserved in ram as the
comment here implied so the immediate reboot wasn't helping anyone.

Depends on https://github.com/coreos/coreos-overlay/pull/651
