### PR TITLE
chore(tmpfiles): drop baselayout-resolv.conf

### DIFF
--- a/tmpfiles.d/baselayout-resolv.conf
+++ b/tmpfiles.d/baselayout-resolv.conf
@@ -1,1 +1,0 @@
-L   /etc/resolv.conf    -   -   -   -   /run/systemd/network/resolv.conf


### PR DESCRIPTION
The target of this symlink changes between systemd v213 and v214 so
the rule should be installed by the systemd ebuild instead.
