### PR TITLE
Set LESSCHARSET to make less output more pretty

### DIFF
--- a/env.d/71less-charset
+++ b/env.d/71less-charset
@@ -1,0 +1,1 @@
+LESSCHARSET="utf-8"


### PR DESCRIPTION
This is especially useful for systemd tools which pipe to less by default and like to put pretty utf8 characters.  You can test this PR by running systemd-cgls.  If you get <E2><94><9C><E2><94><80> garbage, it didn't work.
