### PR TITLE
baselayout: add the rkt group

### DIFF
--- a/baselayout/group
+++ b/baselayout/group
@@ -45,6 +45,7 @@ systemd-journal-gateway:x:247:
 systemd-journal:x:248:core
 dialout:x:249:
 portage:x:250:core
+rkt:x:251:core
 utmp:x:406:
 core:x:500:
 nogroup:x:65533:


### PR DESCRIPTION
the rkt group is the default group for the /var/lib/rkt directory

Before:

    sudo ./rkt install
    install: error looking up rkt gid: "rkt" group not found

After

    sudo ./rkt install
    rkt directory structure successfully created.