### PR TITLE
baselayout: move /home creation to baselayout.conf

### DIFF
--- a/tmpfiles.d/baselayout-home.conf
+++ b/tmpfiles.d/baselayout-home.conf
@@ -1,4 +1,3 @@
-d /home                 -       -       -       -   -
 d /home/core            0755    core    core    -   -
 d /home/core/.ssh       0700    core    core    -   -
 L /home/core/.bash_logout   -   core    core    -   ../../usr/share/skel/.bash_logout

--- a/tmpfiles.d/baselayout.conf
+++ b/tmpfiles.d/baselayout.conf
@@ -1,5 +1,6 @@
 d   /boot       -       -   -   -   -
 d   /dev        -       -   -   -   -
+d   /home       -       -   -   -   -
 d   /media      -       -   -   -   -
 d   /mnt        -       -   -   -   -
 d   /proc       -       -   -   -   -


### PR DESCRIPTION
/home and /home/core creation were both part of baselayout-home.conf,
this poses a problem for initrd usage of systemd-tmpfiles due to how
`systemd-tmpfiles --root` is implemented; it's not performing an actual
chroot, it instead simply prefixes the --root parameter to the paths.

This is arguably a bug in `systemd-tmpfiles --root`, which we may need to
fix in the future.  The core user and group are needed for creating the
/home/core entries with the correct ownership, and they only exist in
/sysroot, not / of the initrd.  As a result systemd-tmpfiles will fail in
creating the /home/core/* entries, even if the core user and group exist in
/sysroot/etc/{passwd,group}, because --root doesn't result in an actual
chroot to /sysroot before attempting to resolve user and group names.

With ignition in the initrd capable of wiping the root filesystem and
needing to add ssh keys to the core user as well as potentially adding
additional users and groups with their own ssh keys, we need to at least
get /home initialized correctly for the shadow utilities ignition leverages
to be usable.

This commit moves the creation of /home to baselayout.conf which is already
applied from within the initrd, and renames baselayout-home.conf to
baselayout-home-core.conf to reflect its narrower /home/core scope.
The baselayout-home.conf wasn't being applied from the initrd, nor is
baselayout-home-core.conf going to be, since it would continue to fail
without fixing `systemd-tmpfiles --root`.

With this change, after systemd-tmpfiles runs from bootengine/80setup-root,
shadowutils should be functional on the sysroot target, which will be used
for creating the core user/group with home directory if necessary.