### PR TITLE
coreos-tmpfiles: copy rkt group to /etc/group

### DIFF
--- a/scripts/coreos-tmpfiles
+++ b/scripts/coreos-tmpfiles
@@ -10,7 +10,7 @@ BASE="${ROOT}/usr/share/baselayout"
 
 # Users/Groups to copy so they can be modified
 COPY_USERS="root|core"
-COPY_GROUPS="docker|sudo|wheel"
+COPY_GROUPS="docker|rkt|sudo|wheel"
 
 # readable files
 umask 022


### PR DESCRIPTION
rkt reads /etc/group directly, also users need to be able to easily add
users to the rkt group which requires it to be in /etc.