### PR TITLE
tmpfiles.d/baselayout.conf: remove home and srv

### DIFF
--- a/tmpfiles.d/baselayout.conf
+++ b/tmpfiles.d/baselayout.conf
@@ -1,13 +1,11 @@
 d   /boot       -       -   -   -   -
 d   /dev        -       -   -   -   -
-d   /home       -       -   -   -   -
 d   /media      -       -   -   -   -
 d   /mnt        -       -   -   -   -
 d   /proc       -       -   -   -   -
 d   /root       0700    -   -   -   -
 d   /run        -       -   -   -   -
 d   /run/lock   -       -   -   -   -
-d   /srv        -       -   -   -   -
 d   /sys        -       -   -   -   -
 d   /var        0755    -   -   -   -
 d   /var/empty  -       -   -   -   -


### PR DESCRIPTION
systemd takes care of home and srv in systemd/tmpfiles.d/home.conf

fixes coreos/bugs#1158