### PR TITLE
scripts: run coreos-tmpfiles after systemd-sysusers

### DIFF
--- a/scripts/coreos-tmpfiles.service
+++ b/scripts/coreos-tmpfiles.service
@@ -2,7 +2,7 @@
 Description=Create missing system files
 DefaultDependencies=no
 After=local-fs.target
-Before=sysinit.target
+Before=sysinit.target systemd-sysusers.service
 ConditionPathIsReadWrite=/etc
 
 [Service]


### PR DESCRIPTION
if systemd-sysusers is executed before coreos-tmpfiles, coreos-tmpfiles
will not copy users into /etc/passwd, resulting in a core user which is
unmodifiable because it only exists in /usr/share/baselayout/passwd.