### PR TITLE
Enable sss in nsswitch.conf by default

### DIFF
--- a/baselayout/nsswitch.conf
+++ b/baselayout/nsswitch.conf
@@ -1,8 +1,8 @@
 # /etc/nsswitch.conf:
 
-passwd:      files usrfiles
-shadow:      files usrfiles
-group:       files usrfiles
+passwd:      files usrfiles sss
+shadow:      files usrfiles sss
+group:       files usrfiles sss
 
 hosts:       files usrfiles dns
 networks:    files usrfiles dns


### PR DESCRIPTION
Now we're shipping sssd we can turn on sss in nsswitch.conf by default. This
will do nothing unless sssd is configured and enabled, but simplifies local
configuration.