### PR TITLE
baselayout: Remove operator's shell

### DIFF
--- a/baselayout/passwd
+++ b/baselayout/passwd
@@ -8,7 +8,7 @@ shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
 halt:x:7:0:halt:/sbin:/sbin/halt
 news:x:9:13:news:/var/spool/news:/sbin/nologin
 uucp:x:10:14:uucp:/var/spool/uucp:/sbin/nologin
-operator:x:11:0:operator:/root:/bin/bash
+operator:x:11:0:operator:/root:/sbin/nologin
 man:x:13:15:man:/usr/share/man:/sbin/nologin
 messagebus:x:201:201:dbus:/dev/null:/sbin/nologin
 syslog:x:202:202:syslog:/dev/null:/sbin/nologin


### PR DESCRIPTION
Operator isn't used in CoreOS, so remove the login shell