### PR TITLE
Move pambase to baselayout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 DESTDIR =
 ETC_DIRS = env.d
-LIB_DIRS = modprobe.d sysctl.d tmpfiles.d systemd
+LIB_DIRS = modprobe.d pam.d sysctl.d tmpfiles.d systemd
 SHARE_DIRS = baselayout vim
 
 all: baselayout/shadow baselayout/gshadow

--- a/pam.d/login
+++ b/pam.d/login
@@ -1,0 +1,6 @@
+auth       required	pam_securetty.so
+auth       include	system-local-login
+account    include	system-local-login
+password   include	system-local-login
+session    optional pam_lastlog.so
+session    include	system-local-login

--- a/pam.d/other
+++ b/pam.d/other
@@ -1,0 +1,4 @@
+auth       required	pam_deny.so
+account    required	pam_deny.so
+password   required	pam_deny.so
+session    required	pam_deny.so

--- a/pam.d/passwd
+++ b/pam.d/passwd
@@ -1,0 +1,4 @@
+auth       sufficient   pam_rootok.so
+auth       include	system-auth
+account    include	system-auth
+password   include	system-auth

--- a/pam.d/su
+++ b/pam.d/su
@@ -1,0 +1,8 @@
+auth       sufficient	pam_rootok.so
+auth       required     pam_wheel.so use_uid
+auth       include		system-auth
+account    include		system-auth
+password   include		system-auth
+session    include		system-auth
+session    required     pam_env.so
+session    optional		pam_xauth.so

--- a/pam.d/system-auth
+++ b/pam.d/system-auth
@@ -1,0 +1,15 @@
+auth		required	pam_env.so
+auth		required	pam_unix.so try_first_pass likeauth nullok
+auth		optional	pam_permit.so
+
+account		required	pam_unix.so
+account		optional	pam_permit.so
+
+password	required	pam_unix.so try_first_pass  nullok md5 shadow
+password	optional	pam_permit.so
+
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so
+session		optional	pam_permit.so
+-session        optional        pam_systemd.so

--- a/pam.d/system-auth
+++ b/pam.d/system-auth
@@ -7,7 +7,7 @@ account		required	pam_unix.so
 account		sufficient	pam_sss.so
 account		optional	pam_permit.so
 
-password	sufficient	pam_unix.so try_first_pass  nullok md5 shadow
+password	sufficient	pam_unix.so try_first_pass  nullok sha512 shadow
 password	sufficient	pam_sss.so use_authtok
 password	required	pam_deny.so
 

--- a/pam.d/system-auth
+++ b/pam.d/system-auth
@@ -1,15 +1,19 @@
 auth		required	pam_env.so
-auth		required	pam_unix.so try_first_pass likeauth nullok
-auth		optional	pam_permit.so
+auth		sufficient	pam_sss.so use_first_pass
+auth		sufficient	pam_unix.so try_first_pass likeauth nullok
+auth		required	pam_deny.so
 
 account		required	pam_unix.so
+account		sufficient	pam_sss.so
 account		optional	pam_permit.so
 
-password	required	pam_unix.so try_first_pass  nullok md5 shadow
-password	optional	pam_permit.so
+password	sufficient	pam_unix.so try_first_pass  nullok md5 shadow
+password	sufficient	pam_sss.so use_authtok
+password	required	pam_deny.so
 
 session		required	pam_limits.so
 session		required	pam_env.so
 session		required	pam_unix.so
 session		optional	pam_permit.so
+session		optional	pam_sss.so
 -session        optional        pam_systemd.so

--- a/pam.d/system-local-login
+++ b/pam.d/system-local-login
@@ -1,0 +1,4 @@
+auth		include		system-login
+account		include		system-login
+password	include		system-login
+session		include		system-login

--- a/pam.d/system-login
+++ b/pam.d/system-login
@@ -1,0 +1,19 @@
+auth		required	pam_tally2.so onerr=succeed
+auth		required	pam_shells.so
+auth		required	pam_nologin.so
+auth		include		system-auth
+ 				
+account		required	pam_access.so
+account		required	pam_nologin.so
+account		include		system-auth
+account		required	pam_tally2.so onerr=succeed
+
+password	include		system-auth
+
+session         optional        pam_loginuid.so
+session		required	pam_env.so
+session		optional	pam_lastlog.so silent
+session		include		system-auth
+session		optional	pam_motd.so motd=/etc/motd
+session		optional	pam_mail.so
+

--- a/pam.d/system-remote-login
+++ b/pam.d/system-remote-login
@@ -1,0 +1,4 @@
+auth		include		system-login
+account		include		system-login
+password	include		system-login
+session		include		system-login

--- a/pam.d/system-services
+++ b/pam.d/system-services
@@ -1,0 +1,7 @@
+auth		sufficient	pam_permit.so
+account		include		system-auth
+session         optional        pam_loginuid.so
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so
+session		optional	pam_permit.so

--- a/pam.d/system-services
+++ b/pam.d/system-services
@@ -5,3 +5,4 @@ session		required	pam_limits.so
 session		required	pam_env.so
 session		required	pam_unix.so
 session		optional	pam_permit.so
+session		optional	pam_sss.so


### PR DESCRIPTION
Gentoo's pambase uses a lot of ifdef magic to support toggling use flags. For the most part we do not need such a dynamic package and it risks subtle compatibility issues in the future. Instead check in the plain ol files directly. pambase will become a stub ebuild for compatibility with portage-stable but otherwise won't be used.