### PR TITLE
tmpfiles: create /etc/hosts if it does not exist

### DIFF
--- a/tmpfiles.d/baselayout-etc.conf
+++ b/tmpfiles.d/baselayout-etc.conf
@@ -1,4 +1,5 @@
 d   /etc                              -   -   -   -   -
+C   /etc/hosts                        -   -   -   -   /usr/share/baselayout/hosts
 L   /etc/inputrc                      -   -   -   -   ../usr/share/baselayout/inputrc
 L   /etc/issue                        -   -   -   -   ../usr/share/baselayout/issue
 L   /etc/motd                         -   -   -   -   ../run/coreos/motd


### PR DESCRIPTION
Thus far we have depended on glibc's nss mechanism to read configuration
from both /etc and /usr so system provided configuration did not need to
exist in the user controlled /etc. In the case of /etc/hosts this has
lead to many problems because 'localhost' must always be resolvable but
often applications use custom resolvers or containers bind mount
/etc/hosts but not the system provided copy under /usr.

For compatibility with existing systems that may have created /etc/hosts
with custom entries but do not include localhost nsswitch.conf must
continue to read from the /usr copy of hosts as well.

Fixes https://github.com/coreos/bugs/issues/1260
