### PR TITLE
tmpfiles: move copy rule to new config

### DIFF
--- a/tmpfiles.d/baselayout-etc.conf
+++ b/tmpfiles.d/baselayout-etc.conf
@@ -1,5 +1,4 @@
 d   /etc                              -   -   -   -   -
-C   /etc/hosts                        -   -   -   -   /usr/share/baselayout/hosts
 L   /etc/inputrc                      -   -   -   -   ../usr/share/baselayout/inputrc
 L   /etc/issue                        -   -   -   -   ../usr/share/baselayout/issue
 L   /etc/motd                         -   -   -   -   ../run/coreos/motd

--- a/tmpfiles.d/baselayout-hosts.conf
+++ b/tmpfiles.d/baselayout-hosts.conf
@@ -1,0 +1,1 @@
+C   /etc/hosts      -   -   -   -   /usr/share/baselayout/hosts


### PR DESCRIPTION
Copy rules are always use the given absolute path, regardless of --root.
This means that when baselayout-etc.conf is executed in the initrd it
fails because /usr/share/baselayout is not included in the initrd. Move
the copy rule to a new config that does not get executed so early.