### PR TITLE
Remove pam_wheel.so from su PAM configuration

### DIFF
--- a/pam.d/su
+++ b/pam.d/su
@@ -1,5 +1,4 @@
 auth       sufficient	pam_rootok.so
-auth       required     pam_wheel.so use_uid
 auth       include		system-auth
 account    include		system-auth
 password   include		system-auth


### PR DESCRIPTION
We don't want to restrict su to members of the wheel group, so remove this from
the configuration.