### PR TITLE
baselayout: Allow pam_sss to reject users

### DIFF
--- a/pam.d/system-auth
+++ b/pam.d/system-auth
@@ -4,7 +4,8 @@ auth		sufficient	pam_unix.so try_first_pass likeauth nullok
 auth		required	pam_deny.so
 
 account		required	pam_unix.so
-account		sufficient	pam_sss.so
+# Don't fail if the user is unknown to sssd or if sssd isn't running
+account		required	pam_sss.so ignore_unknown_user ignore_authinfo_unavail
 account		optional	pam_permit.so
 
 password	sufficient	pam_unix.so try_first_pass  nullok sha512 shadow


### PR DESCRIPTION
sssd has support for whitelisting or blacklisting users and groups. To do
so, pam_sss must be able to block login, which means it has to be listed as
required in the account section of sys-auth. The ignore_unknown_user and
ignore_authinfo_unavail mean that it will not block logins if the user is
unknown by sssd or if pam_sss is unable to communicate with sssd.