### PR TITLE
pam.d: add the systemd-user service from upstream

### DIFF
--- a/pam.d/systemd-user
+++ b/pam.d/systemd-user
@@ -1,0 +1,4 @@
+account  include system-auth
+
+session  required pam_loginuid.so
+session  include system-auth


### PR DESCRIPTION
This is for coreos/bugs#1498.