### PR TITLE
systemd: disable resolved's stub listener for v232

### DIFF
--- a/systemd/resolved.conf.d/50-no-dns-listener.conf
+++ b/systemd/resolved.conf.d/50-no-dns-listener.conf
@@ -1,0 +1,4 @@
+# The DNS stub listener in systemd-resolved will listen on 127.0.0.53:53, which
+# can conflict with other DNS services that listen on local interfaces.
+[Resolve]
+DNSStubListener=no


### PR DESCRIPTION
This shouldn't be merged until after coreos/systemd#69.