### PR TITLE
pam.d: sync systemd-user with v233

### DIFF
--- a/pam.d/systemd-user
+++ b/pam.d/systemd-user
@@ -1,4 +1,4 @@
-account  include system-auth
-
-session  required pam_loginuid.so
-session  include system-auth
+account include system-auth
+session include system-auth
+session optional pam_keyinit.so force revoke
+session optional pam_systemd.so


### PR DESCRIPTION
This is really just Gentoo's `233-systemd-user-pam.patch`.  A change from our point of view is that this gives new kernel keyrings to new user sessions.