### PR TITLE
nsswitch: use nss-myhostname

### DIFF
--- a/baselayout/nsswitch.conf
+++ b/baselayout/nsswitch.conf
@@ -4,7 +4,7 @@ passwd:      files usrfiles sss
 shadow:      files usrfiles sss
 group:       files usrfiles sss
 
-hosts:       files usrfiles dns
+hosts:       files usrfiles dns myhostname
 networks:    files usrfiles dns
 
 services:    files usrfiles


### PR DESCRIPTION
This modules ensures that `hostname -s` and `hostname -i` will always
return something.

It's prioritized last so any existing hostname configuration (e.g. in
/etc/hosts) will still work correctly.

This configuration is similar to what most distributions do.

See https://github.com/coreos/bugs/issues/1764