### PR TITLE
modprobe.d: don't automatically create bond0 upon bonding driver load

### DIFF
--- a/modprobe.d/bond.conf
+++ b/modprobe.d/bond.conf
@@ -1,0 +1,4 @@
+# By default the bonding driver automatically creates a bond0 device, but
+# networkd refuses to apply systemd.netdev(5) parameters to an interface
+# that already exists. Disable automatic creation of bond0.
+options bonding max_bonds=0


### PR DESCRIPTION
Needed for Packet, and probably useful in general.