### PR TITLE
coreos-profile: Show update status using conf file

### DIFF
--- a/baselayout/coreos-profile.sh
+++ b/baselayout/coreos-profile.sh
@@ -2,8 +2,34 @@
 
 # Only print for interactive shells.
 if [[ $- == *i* ]]; then
-	if ! systemctl is-active locksmithd > /dev/null; then
+	if ! [ -f  /run/update-engine/coordinator.conf ]; then
+		# No coordinator running
 		echo -e "Update Strategy: \033[31mNo Reboots\033[39m"
+	elif flock --nonblock --exclusive /run/update-engine/coordinator.conf --command /bin/true &>/dev/null; then
+		# Coordinator ran, but isn't currently running
+		echo -e "Update Strategy: \033[31mNo Reboots\033[39m"
+	else
+		# subshell to avoid env pollution
+		(
+			# Helper warn if disabled or rebooting soon
+			warn() {
+					echo -e "Update Status: \033[33m${NAME} - ${1}\033[39m"
+			}
+			source /run/update-engine/coordinator.conf
+			case "${STATE}" in
+				running|starting)
+					;;
+				disabled)
+					warn "Updates disabled"
+					;;
+				rebooting|reboot-planned)
+					warn "Reboot planned"
+					;;
+				*)
+					warn "${STATE}"
+					;;
+			esac
+		)
 	fi
 
 	FAILED=$(systemctl list-units --state=failed --no-legend)


### PR DESCRIPTION
This coordinator conf file is being introduced in locksmith and the
Container Linux Update Operator.

This allows the profile to correctly display information about the
update strategy regardless whether it's being managed by locksmithd or
cluo.

See https://github.com/coreos/container-linux-update-operator/issues/88

Depends on https://github.com/coreos/locksmith/pull/127 being shipped along with this change