### PR TITLE
baselayout/nsswitch.conf: Use nss-systemd for passwd/group

### DIFF
--- a/baselayout/group
+++ b/baselayout/group
@@ -35,14 +35,11 @@ etcd:x:232:
 docker:x:233:core
 tlsdate:x:234:
 polkitd:x:235:
-systemd-journal-upload:x:241:
 systemd-journal-remote:x:242:
-systemd-timesync:x:243:
 systemd-network:x:244:
 systemd-resolve:x:245:
 systemd-bus-proxy:x:246:
-systemd-journal-gateway:x:247:
-systemd-journal:x:248:core,systemd-journal-upload
+systemd-journal:x:248:core
 dialout:x:249:
 portage:x:250:core
 tss:x:252:tss

--- a/baselayout/nsswitch.conf
+++ b/baselayout/nsswitch.conf
@@ -1,8 +1,8 @@
 # /etc/nsswitch.conf:
 
-passwd:      files usrfiles sss
+passwd:      files usrfiles sss systemd
 shadow:      files usrfiles sss
-group:       files usrfiles sss
+group:       files usrfiles sss systemd
 
 hosts:       files usrfiles dns myhostname
 networks:    files usrfiles dns

--- a/baselayout/passwd
+++ b/baselayout/passwd
@@ -21,13 +21,10 @@ docker:x:233:233::/dev/null:/sbin/nologin
 tlsdate:x:234:234::/dev/null:/sbin/nologin
 polkitd:x:235:235:Policy Toolkit:/var/lib/polkit-1:/sbin/nologin
 tss:x:236:236:TCG Software Stack:/dev/null:/sbin/nologin
-systemd-journal-upload:x:241:241:Journal Upload:/dev/null:/sbin/nologin
 systemd-journal-remote:x:242:242:Journal Remote:/dev/null:/sbin/nologin
-systemd-timesync:x:243:243:Network Time Synchronization:/dev/null:/sbin/nologin
 systemd-network:x:244:244:Network Management Service:/dev/null:/sbin/nologin
 systemd-resolve:x:245:245:Network Name Resolution:/dev/null:/sbin/nologin
 systemd-bus-proxy:x:246:246:Legacy D-Bus Proxy:/dev/null:/sbin/nologin
-systemd-journal-gateway:x:247:247:Journal Gateway:/var/log/journal:/sbin/nologin
 portage:x:250:250:portage:/var/tmp/portage:/sbin/nologin
 core:x:500:500:CoreOS Admin:/home/core:/bin/bash
 nobody:x:65534:65534:nobody:/var/empty:/sbin/nologin


### PR DESCRIPTION
This supports resolving dynamic users, which systemd 236 uses by default for some of its services.