### PR TITLE
modprobe.d: Preserve the pre-4.15 rbd module behavior

### DIFF
--- a/modprobe.d/rbd.conf
+++ b/modprobe.d/rbd.conf
@@ -1,0 +1,2 @@
+# Preserve the pre-4.15 kernel behavior.
+options rbd single_major=N


### PR DESCRIPTION
The default changed in torvalds/linux@3cfa3b16dd2f1787f9d19d6da2fe9652d806b387 so that `/sys/bus/rbd/add` no longer works.  Since Container Linux does not include the userspace utilities which previously set the option to its new default, users might depend on the old behavior.