### PR TITLE
sysctl: Revert new protections from systemd 241

### DIFF
--- a/sysctl.d/baselayout.conf
+++ b/sysctl.d/baselayout.conf
@@ -10,3 +10,7 @@ net.ipv4.conf.all.rp_filter = 1
 
 # Disable kernel address visibility to non-root users.
 kernel.kptr_restrict = 1
+
+# Disable regular file and FIFO protection for compatibility.
+fs.protected_regular = 0
+fs.protected_fifos = 0


### PR DESCRIPTION
Undo systemd/systemd#11442 for coreos/bugs#2577 to avoid breaking users at this point in the Container Linux life cycle.  The security improvements are left enabled in Fedora 30, so Fedora CoreOS will benefit from the upstream change.